### PR TITLE
Allow choosing between CPU and GPU Pytorch

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Enno Hermann
+#
+# SPDX-License-Identifier: CC0-1.0
+
+name: Setup uv
+runs:
+  using: 'composite'
+  steps:
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        version: "0.7.6"
+        python-version: ${{ matrix.python-version }}

--- a/.github/scripts/add_uv_constraints.py
+++ b/.github/scripts/add_uv_constraints.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Enno Hermann
+#
+# SPDX-License-Identifier: MIT
+
+# /// script
+# requires-python = ">=3.12"
+# dependencies = [
+#     "tomli-w",
+# ]
+# ///
+
+"""Add uv dependency constraints to the pyproject.toml file.
+
+Usage:
+$ .github/scripts/add_uv_constraints.py numpy==1.26.4 torch==2.2.2
+"""
+
+import sys
+from pathlib import Path
+
+import tomli_w
+import tomllib
+
+with Path("pyproject.toml").open("rb") as f:
+    toml = tomllib.load(f)
+
+if "constraint-dependencies" not in toml["tool"]["uv"]:
+    toml["tool"]["uv"]["constraint-dependencies"] = []
+
+for dep in sys.argv[1:]:
+    toml["tool"]["uv"]["constraint-dependencies"].append(
+        f"{dep}; platform_system == 'Linux'",
+    )
+
+with Path("pyproject.toml").open("wb") as f:
+    tomli_w.dump(toml, f)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Setup uv
         uses: ./.github/actions/setup-uv
       - name: Lint check
-        run: uv run pre-commit run --all-files
+        run: uv run --only-dev pre-commit run --all-files
       - name: Mypy
-        run: uv run mypy --strict src/
+        run: uv run --extra cpu mypy --strict src/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,12 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: "0.4.30"
-          enable-cache: true
-          cache-dependency-glob: "**/pyproject.toml"
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
       - name: Lint check
         run: uv run pre-commit run --all-files
       - name: Mypy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.9, "3.10", "3.11", "3.12", "3.13"]
-        uv-resolution: ["lowest-direct", "highest"]
+        include:
+          - python-version: "3.9"
+            numpy-version: "--with numpy==1.21.6"
+            torch-version: "--with torch==1.12.1+cpu"
+          - python-version: "3.10"
+            numpy-version: "--with numpy==1.21.6"
+            torch-version: "--with torch==1.12.1+cpu"
+          - python-version: "3.11"
+            numpy-version: "--with numpy==1.24.4"
+            torch-version: "--with torch==2.1.1+cpu"
+          - python-version: "3.12"
+            numpy-version: "--with numpy==1.26.4"
+            torch-version: "--with torch==2.2.2+cpu"
+          - python-version: "3.13"
     steps:
       - uses: actions/checkout@v4
       - name: Install uv
@@ -27,14 +39,15 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "**/pyproject.toml"
       - name: Tests
-        run: uv run --python=${{ matrix.python-version }} --resolution=${{ matrix.uv-resolution }} coverage run --parallel
-      - name: List packages
-        run: uv pip list
+        run: |
+          uv run -v --python=${{ matrix.python-version }} \
+            ${{ matrix.numpy-version }} ${{ matrix.torch-version}} \
+            coverage run --parallel
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:
           include-hidden-files: true
-          name: coverage-data-${{ matrix.python-version }}-${{ matrix.uv-resolution }}
+          name: coverage-data-${{ matrix.python-version }}
           path: .coverage.*
           if-no-files-found: ignore
   coverage:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,17 +18,17 @@ jobs:
       matrix:
         include:
           - python-version: "3.9"
-            numpy-version: "--with numpy==1.21.6"
-            torch-version: "--with torch==1.12.1+cpu"
+            numpy-version: "numpy==1.21.6"
+            torch-version: "torch==1.12.1"
           - python-version: "3.10"
-            numpy-version: "--with numpy==1.21.6"
-            torch-version: "--with torch==1.12.1+cpu"
+            numpy-version: "numpy==1.21.6"
+            torch-version: "torch==1.12.1"
           - python-version: "3.11"
-            numpy-version: "--with numpy==1.24.4"
-            torch-version: "--with torch==2.1.1+cpu"
+            numpy-version: "numpy==1.24.4"
+            torch-version: "torch==2.1.1"
           - python-version: "3.12"
-            numpy-version: "--with numpy==1.26.4"
-            torch-version: "--with torch==2.2.2+cpu"
+            numpy-version: "numpy==1.26.4"
+            torch-version: "torch==2.2.2"
           - python-version: "3.13"
     steps:
       - uses: actions/checkout@v4
@@ -36,12 +36,11 @@ jobs:
         uses: ./.github/actions/setup-uv
       - name: Tests
         run: |
+          uv run -v --python 3.12 .github/scripts/add_uv_constraints.py \
+            ${{ matrix.numpy-version }} \
+            ${{ matrix.torch-version }}
           uv sync
-          uv run -v --extra cpu \
-            --index https://download.pytorch.org/whl/cpu \
-            --index-strategy unsafe-best-match \
-            ${{ matrix.numpy-version }} ${{ matrix.torch-version}} \
-            coverage run --parallel
+          uv run -v --extra cpu coverage run --parallel
       - name: Upload coverage data
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,10 @@ jobs:
         uses: ./.github/actions/setup-uv
       - name: Tests
         run: |
-          uv run --python=${{ matrix.python-version }} \
+          uv sync
+          uv run -v --extra cpu \
+            --index https://download.pytorch.org/whl/cpu \
+            --index-strategy unsafe-best-match \
             ${{ matrix.numpy-version }} ${{ matrix.torch-version}} \
             coverage run --parallel
       - name: Upload coverage data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,15 +32,11 @@ jobs:
           - python-version: "3.13"
     steps:
       - uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: "0.4.30"
-          enable-cache: true
-          cache-dependency-glob: "**/pyproject.toml"
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
       - name: Tests
         run: |
-          uv run -v --python=${{ matrix.python-version }} \
+          uv run --python=${{ matrix.python-version }} \
             ${{ matrix.numpy-version }} ${{ matrix.torch-version}} \
             coverage run --parallel
       - name: Upload coverage data
@@ -56,10 +52,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install uv
-        uses: astral-sh/setup-uv@v3
-        with:
-          version: "0.4.30"
+      - name: Setup uv
+        uses: ./.github/actions/setup-uv
       - uses: actions/download-artifact@v4
         with:
           pattern: coverage-data-*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,9 +11,9 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.2
+    rev: v0.11.10
     hooks:
-      - id: ruff
+      - id: ruff-check
       - id: ruff-format
   - repo: https://github.com/fsfe/reuse-tool
     rev: d6a8b11c3662ade803dcd3e585d49b78524e8bd5

--- a/README.md
+++ b/README.md
@@ -21,7 +21,14 @@ for easy reuse in other projects.
 pip install monotonic-alignment-search
 ```
 
-Wheels are provided for Linux, Mac, and Windows.
+Wheels are provided for Linux, Mac, and Windows. Pytorch is not installed by
+default. You either first need to install it yourself, or install one of the
+following extras with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv add monotonic-alignment-search[cpu]
+uv add monotonic-alignment-search[cuda]
+```
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,7 +88,7 @@ dev = [
     "pre-commit>=4.0.1",
     "pytest>=8.3.3",
     "reuse>=4.0.3",
-    "ruff>=0.7.2",
+    "ruff==0.11.10",
 ]
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,14 +34,8 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio :: Speech",
 ]
 dependencies = [
-    "numpy>=1.21.6; python_version < '3.11'",
-    "numpy>=1.24.4; python_version == '3.11'",
-    "numpy>=1.26.4; python_version == '3.12'",
-    "numpy>=2.1.3; python_version == '3.13'",
-    "torch>=1.12.1; python_version < '3.11'",
-    "torch>=2.1.1; python_version == '3.11'",
-    "torch>=2.2; python_version == '3.12'",
-    "torch>=2.5.1; python_version == '3.13'",
+    "numpy>=1.21.6",
+    "torch>=1.12.1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "monotonic-alignment-search"
-version = "0.1.1"
+version = "0.2.0"
 description = "Monotonically align text and speech"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,39 @@ classifiers = [
 ]
 dependencies = [
     "numpy>=1.21.6",
+]
+
+[project.optional-dependencies]
+cpu = [
     "torch>=1.12.1",
 ]
+cuda = [
+    "torch>=1.12.1",
+]
+
+[tool.uv]
+conflicts = [
+  [
+    { extra = "cpu" },
+    { extra = "cuda" },
+  ],
+]
+
+[tool.uv.sources]
+torch = [
+  { index = "pytorch-cpu", extra = "cpu", marker = "platform_system != 'Darwin'" },
+  { index = "pytorch-cuda", extra = "cuda", marker = "platform_system == 'Windows'" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cuda"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true
 
 [project.urls]
 Repository = "https://github.com/eginhard/monotonic_alignment_search"


### PR DESCRIPTION
- Don't install Pytorch by default anymore. Instead, the `cpu` and `cuda` extras can be used to install the respective version (based on https://docs.astral.sh/uv/guides/integration/pytorch/). This way we can just install CPU Pytorch in CI.
- Test a wider range of Numpy and Pytorch versions.
- Update dev dependencies.